### PR TITLE
IP Reservation Support For New Endpoints

### DIFF
--- a/instance_ips.go
+++ b/instance_ips.go
@@ -31,6 +31,7 @@ type InstanceIP struct {
 	LinodeID   int                `json:"linode_id"`
 	Region     string             `json:"region"`
 	VPCNAT1To1 *InstanceIPNAT1To1 `json:"vpc_nat_1_1"`
+	Reserved   bool               `json:"reserved"`
 }
 
 // VPCIP represents a private IP address in a VPC subnet with additional networking details

--- a/network_reserved_ips.go
+++ b/network_reserved_ips.go
@@ -1,0 +1,49 @@
+package linodego
+
+import (
+	"context"
+)
+
+// ReserveIPOptions represents the options for reserving an IP address
+type ReserveIPOptions struct {
+	Region string `json:"region"`
+}
+
+// GetReservedIPs retrieves a list of reserved IP addresses
+func (c *Client) GetReservedIPs(ctx context.Context, opts *ListOptions) ([]InstanceIP, error) {
+	e := formatAPIPath("networking/reserved/ips")
+	response, err := getPaginatedResults[InstanceIP](ctx, c, e, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// GetReservedIPAddress retrieves details of a specific reserved IP address
+func (c *Client) GetReservedIPAddress(ctx context.Context, id string) (*InstanceIP, error) {
+	e := formatAPIPath("networking/reserved/ips/%s", id)
+	response, err := doGETRequest[InstanceIP](ctx, c, e)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// ReserveIPAddress reserves a new IP address
+func (c *Client) ReserveIPAddress(ctx context.Context, opts ReserveIPOptions) (*InstanceIP, error) {
+	e := "networking/reserved/ips"
+	response, err := doPOSTRequest[InstanceIP](ctx, c, e, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+// DeleteReservedIPAddress deletes a reserved IP address
+func (c *Client) DeleteReservedIPAddress(ctx context.Context, ipAddress string) error {
+	e := formatAPIPath("networking/reserved/ips/%s", ipAddress)
+	return doDELETERequest(ctx, c, e)
+}

--- a/test/integration/fixtures/TestReservedIPAddresses_DeleteIPAddressVariants.yaml
+++ b/test/integration/fixtures/TestReservedIPAddresses_DeleteIPAddressVariants.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips?page=1
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:45 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestReservedIPAddresses_GetIPAddressVariants.yaml
+++ b/test/integration/fixtures/TestReservedIPAddresses_GetIPAddressVariants.yaml
@@ -1,0 +1,46 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestReservedIPAddresses_ListIPAddressesVariants.yaml
+++ b/test/integration/fixtures/TestReservedIPAddresses_ListIPAddressesVariants.yaml
@@ -1,0 +1,50 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips?page=1
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestReservedIPAddresses_ReserveIPVariants.yaml
+++ b/test/integration/fixtures/TestReservedIPAddresses_ReserveIPVariants.yaml
@@ -1,0 +1,218 @@
+---
+version: 1
+interactions:
+- request:
+    body: '{"region":""}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":"us"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":""}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:45 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:45 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestReservedIpAddresses_EndToEndTest.yaml
+++ b/test/integration/fixtures/TestReservedIpAddresses_EndToEndTest.yaml
@@ -1,0 +1,93 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips?page=1
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/fixtures/TestReservedIpAddresses_InsufficientPermissions.yaml
+++ b/test/integration/fixtures/TestReservedIpAddresses_InsufficientPermissions.yaml
@@ -1,0 +1,185 @@
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips?page=1
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:43 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: '{"region":"us-east"}'
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips
+    method: POST
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:43 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/172.28.3.4
+    method: GET
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:43 GMT
+      Pragma:
+      - no-cache
+      Vary:
+      - Authorization, X-Filter
+      X-Accepted-Oauth-Scopes:
+      - ips:read_only
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      User-Agent:
+      - linodego/dev https://github.com/linode/linodego
+    url: https://api.linode.com/v4beta/networking/reserved/ips/172.28.3.4
+    method: DELETE
+  response:
+    body: '{"errors": [{"reason": "Account doesn''t have permission to access the
+      ''Reserved IPs'' feature."}]}'
+    headers:
+      Access-Control-Allow-Headers:
+      - Authorization, Origin, X-Requested-With, Content-Type, Accept, X-Filter
+      Access-Control-Allow-Methods:
+      - HEAD, GET, OPTIONS, POST, PUT, DELETE
+      Access-Control-Allow-Origin:
+      - '*'
+      Akamai-Internal-Account:
+      - '*'
+      Cache-Control:
+      - max-age=0, no-cache, no-store
+      Connection:
+      - keep-alive
+      Content-Length:
+      - "97"
+      Content-Type:
+      - application/json
+      Expires:
+      - Thu, 22 Aug 2024 20:10:44 GMT
+      Pragma:
+      - no-cache
+      X-Accepted-Oauth-Scopes:
+      - ips:read_write
+      X-Frame-Options:
+      - DENY
+      X-Oauth-Scopes:
+      - '*'
+    status: 404 Not Found
+    code: 404
+    duration: ""

--- a/test/integration/network_reserved_ips_test.go
+++ b/test/integration/network_reserved_ips_test.go
@@ -1,0 +1,284 @@
+package integration
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	. "github.com/linode/linodego"
+)
+
+// TestReservedIPAddresses_InsufficientPermissions tests the behavior when a user account
+// doesn't have the can_reserve_ip flag enabled
+func TestReservedIPAddresses_InsufficientPermissions(t *testing.T) {
+	original := os.Getenv("LINODE_TOKEN")
+	dummyToken := "badtoken"
+	os.Setenv("LINODE_TOKEN", dummyToken)
+
+	client, teardown := createTestClient(t, "fixtures/TestReservedIpAddresses_InsufficientPermissions")
+	defer teardown()
+	defer os.Setenv("LINODE_TOKEN", original)
+
+	filter := ""
+	i, getReservedIpsError := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+	if getReservedIpsError != nil {
+		t.Logf("Error listing ipaddresses, expected struct, got error %v", getReservedIpsError)
+	}
+
+	if len(i) == 0 {
+		t.Logf("Expected a list of ipaddresses, but got none %v", i)
+	}
+
+	// Attempt to reserve an IP address
+	reservedIp, reserveIpError := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us-east",
+	})
+	if reserveIpError != nil {
+		t.Logf("Failed to reserve IP: %v", reserveIpError)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", reservedIp)
+	}
+
+	// Attempt to get a reserved IP address
+	address := "172.28.3.4"
+	ipaddress, getReservedIpError := client.GetReservedIPAddress(context.Background(), address)
+	if getReservedIpError != nil {
+		t.Logf("Error getting ipaddress, expected struct, got %v and error %v", ipaddress, getReservedIpError)
+	}
+
+	// Attempt to delete a reserved IP address
+	addressToBeDeleted := "172.28.3.4"
+	deleterr := client.DeleteReservedIPAddress(context.Background(), addressToBeDeleted)
+	if deleterr != nil {
+		t.Logf("Error deleting reserved IP address: %v", deleterr)
+	} else {
+		t.Logf("Successfully deleted reserved IP address: %s", addressToBeDeleted)
+	}
+}
+
+// TestReservedIPAddresses_EndToEndTest performs an end-to-end test of the Reserved IP functionality
+// for users with the can_reserve_ip flag enabled
+func TestReservedIPAddresses_EndToEndTest(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIpAddresses_EndToEndTest")
+	defer teardown()
+
+	filter := ""
+	ipList, listIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+	if listIpErr != nil {
+		t.Logf("Error listing ipaddresses, expected struct, got error %v", listIpErr)
+	} else {
+		if len(ipList) == 0 {
+			t.Logf("The customer has not reserved an IP %v", ipList)
+		}
+	}
+
+	// Attempt to reserve an IP
+	reserveIP, reserveIpErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us-east",
+	})
+	if reserveIpErr != nil {
+		t.Logf("Failed to reserve IP: %v", reserveIpErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", reserveIP)
+	}
+
+	if reserveIP != nil {
+		// Fetch the reserved IP
+		reservedIP, fetchIpErr := client.GetReservedIPAddress(context.Background(), reserveIP.Address)
+		if fetchIpErr != nil {
+			t.Logf("Error getting ipaddress, expected struct, got %v and error %v", reservedIP, fetchIpErr)
+		}
+
+		// Verify the list of IPs has increased
+		verifyList, verifyListIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+		if verifyListIpErr != nil {
+			t.Logf("Error listing ipaddresses, expected struct, got error %v", verifyListIpErr)
+		} else {
+			if len(verifyList)-len(ipList) == 1 {
+				t.Log("Increase in IP list confirmed", verifyList)
+			} else {
+				t.Errorf("Increase in IP list not confirmed")
+			}
+		}
+
+		// Delete the reserved IP
+		if reserveIP != nil {
+			deleteErr := client.DeleteReservedIPAddress(context.Background(), reserveIP.Address)
+			if deleteErr != nil {
+				t.Logf("Error deleting reserved IP address: %v", deleteErr)
+			} else {
+				t.Logf("Successfully deleted reserved IP address: %s", reserveIP.Address)
+			}
+		}
+
+		// Verify the IP has been deleted
+		if reserveIP != nil {
+			verifyDeletedIP, fetchDeletedIpErr := client.GetReservedIPAddress(context.Background(), reserveIP.Address)
+			if fetchDeletedIpErr != nil {
+				t.Logf("Error getting ipaddress, expected struct, got %v and error %v", verifyDeletedIP, fetchDeletedIpErr)
+			}
+
+			verifyDeletedFromList, verifyDeletedFromListIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+			if verifyDeletedFromListIpErr != nil {
+				t.Logf("Error listing ipaddresses, expected struct, got error %v", verifyDeletedFromListIpErr)
+			} else {
+				if len(verifyDeletedFromList) < len(verifyList) {
+					t.Log("IP address deletion confirmed", verifyDeletedFromList)
+				} else {
+					t.Errorf("Verification - Failed")
+				}
+			}
+		}
+	}
+}
+
+// TestReservedIPAddresses_ListIPAddressesVariants tests various scenarios for listing IP addresses
+func TestReservedIPAddresses_ListIPAddressesVariants(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddresses_ListIPAddressesVariants")
+	defer teardown()
+
+	filter := ""
+	ipList, listIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+	if listIpErr != nil {
+		t.Logf("Error listing ipaddresses, expected struct, got error %v", listIpErr)
+	} else {
+		if len(ipList) == 0 {
+			t.Logf("The customer has not reserved an IP %v", ipList)
+		}
+	}
+}
+
+// TestReservedIPAddresses_GetIPAddressVariants tests various scenarios for getting a specific IP address
+func TestReservedIPAddresses_GetIPAddressVariants(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddresses_GetIPAddressVariants")
+	defer teardown()
+
+	// Reserve an IP for testing
+	reserveIP, reserveIpErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us-east",
+	})
+	if reserveIpErr != nil {
+		t.Logf("Failed to reserve IP: %v", reserveIpErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", reserveIP)
+	}
+
+	if reserveIP != nil {
+		// Test getting a valid reserved IP
+		validReservedIP, validFetchIpErr := client.GetReservedIPAddress(context.Background(), reserveIP.Address)
+		if validFetchIpErr != nil {
+			t.Logf("Error getting ipaddress, expected struct, got %v and error %v", validReservedIP, validFetchIpErr)
+		}
+
+		// Test getting an invalid IP
+		invalidReservedIP, invalidFetchIpErr := client.GetReservedIPAddress(context.Background(), "INVALID_IP")
+		if invalidFetchIpErr != nil {
+			t.Logf("Error getting ipaddress, expected struct, got %v and error %v", invalidReservedIP, invalidFetchIpErr)
+		}
+	}
+}
+
+// TestReservedIPAddresses_ReserveIPVariants tests various scenarios for reserving an IP address
+func TestReservedIPAddresses_ReserveIPVariants(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddresses_ReserveIPVariants")
+	defer teardown()
+
+	// Test reserving IP with omitted region
+	omitRegion, omitRegionErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{})
+	if omitRegionErr != nil {
+		t.Logf("Failed to reserve IP: %v", omitRegionErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", omitRegion)
+	}
+
+	// Test reserving IP with invalid region
+	invalidRegion, invalidRegionErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us",
+	})
+	if invalidRegionErr != nil {
+		t.Logf("Failed to reserve IP: %v", invalidRegionErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", invalidRegion)
+	}
+
+	// Test reserving IP with empty region
+	emptyRegion, emptyRegionErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "",
+	})
+	if emptyRegionErr != nil {
+		t.Logf("Failed to reserve IP: %v", emptyRegionErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", emptyRegion)
+	}
+
+	// Test valid IP reservation
+	validReservation, validReservationErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us-east",
+	})
+	if validReservationErr != nil {
+		t.Logf("Failed to reserve IP: %v", validReservationErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", validReservation)
+	}
+
+	// Test exceeding reservation limit
+	exceedReservationLimit, exceedReservationErr := client.ReserveIPAddress(context.Background(), ReserveIPOptions{
+		Region: "us-east",
+	})
+	if exceedReservationErr != nil {
+		t.Logf("Failed to reserve IP: %v", exceedReservationErr)
+	} else {
+		t.Logf("Successfully reserved IP: %+v", exceedReservationLimit)
+	}
+}
+
+// TestReservedIPAddresses_DeleteIPAddressVariants tests various scenarios for deleting a reserved IP address
+func TestReservedIPAddresses_DeleteIPAddressVariants(t *testing.T) {
+	client, teardown := createTestClient(t, "fixtures/TestReservedIPAddresses_DeleteIPAddressVariants")
+	defer teardown()
+
+	filter := ""
+	ipList, listIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+	if listIpErr != nil {
+		t.Logf("Error listing ipaddresses, expected struct, got error %v", listIpErr)
+	} else {
+		if len(ipList) == 0 {
+			t.Logf("The customer has not reserved an IP %v", ipList)
+		}
+	}
+
+	if len(ipList) > 0 {
+		ipToBeDeleted := ipList[len(ipList)-1]
+		deleteErr := client.DeleteReservedIPAddress(context.Background(), ipToBeDeleted.Address)
+		if deleteErr != nil {
+			t.Logf("Error deleting reserved IP address: %v", deleteErr)
+		} else {
+			t.Logf("Successfully deleted reserved IP address: %s", ipToBeDeleted.Address)
+		}
+
+		// Verify deletion
+		verifyDeletedFromList, verifyDeletedFromListIpErr := client.GetReservedIPs(context.Background(), NewListOptions(0, filter))
+		if verifyDeletedFromListIpErr != nil {
+			t.Logf("Error listing ipaddresses, expected struct, got error %v", verifyDeletedFromListIpErr)
+		} else {
+			if len(verifyDeletedFromList) < len(ipList) {
+				t.Log("IP address deletion confirmed", verifyDeletedFromList)
+			} else {
+				t.Errorf("Verification - Failed")
+			}
+		}
+
+		verifyDeletedIP, fetchDeletedIpErr := client.GetReservedIPAddress(context.Background(), ipToBeDeleted.Address)
+		if fetchDeletedIpErr != nil {
+			t.Logf("IP address not found got %v and error %v", verifyDeletedIP, fetchDeletedIpErr)
+		}
+
+		// Test deleting an unowned IP
+		deletingUnownedIPErr := client.DeleteReservedIPAddress(context.Background(), "255.255.255.4")
+		if deletingUnownedIPErr != nil {
+			t.Logf("Error deleting reserved IP address: %v", deletingUnownedIPErr)
+		} else {
+			t.Logf("Successfully deleted reserved IP address: %s", "255.255.255.4")
+		}
+	}
+}


### PR DESCRIPTION
## 📝 Description

This PR introduces comprehensive functionality and tests for Reserved IP Addresses in the Linodego client. The changes are necessary to provide robust support for managing Reserved IP addresses through the Linode API. The changes include:
1. Implementation of core Reserved IP operations:
* Listing Reserved IPs
* Getting a specific Reserved IP
* Reserving a new IP
* Deleting a Reserved IP
2. Test coverage:
* TestReservedIPAddresses_InsufficientPermissions: Verifies behavior when the user lacks necessary permissions.
* TestReservedIPAddresses_EndToEndTest: Performs a complete workflow test for users with proper permissions.
* TestReservedIPAddresses_ListIPAddressesVariants: Tests various scenarios for listing IP addresses.
* TestReservedIPAddresses_GetIPAddressVariants: Covers different cases for retrieving a specific IP address.
* TestReservedIPAddresses_ReserveIPVariants: Tests multiple scenarios for reserving an IP, including edge cases.
* TestReservedIPAddresses_DeleteIPAddressVariants: Verifies deletion functionality under various conditions.

## ✔️ How to Test

To verify the changes related to Reserved IP functionality, follow these steps:
1. Ensure you have a valid Linode API token with the "can_reserve_ip" permission enabled. Set up your environment: 
`export LINODE_TOKEN="your_token_here"` 
Additionally you need to set the following if you want to test it in a different environment: 
  ```
   export LINODE_URL="https://api.linode.com"
   export LINODE_API_VERSION="v4beta"
  ```
2. Navigate to the test directory within the linodego project. Update the LINODE_TOKEN in the Makefile: `LINODE_TOKEN="your_token_here"`
3. Run the tests using one of the following commands: 
 To run all integration tests: make testint 
 To run only Reserved IP related tests: go test -v ./integration -run 
 TestReservedIPAddresses 
 To run a specific test: go test -v ./integration -run TestReservedIPAddresses_EndToEndTest

4. Verify the test output for any failures or unexpected behavior.

Note:
* Ensure you have proper permissions and sufficient quota in your Linode account to perform Reserved IP operations. Some tests may create and delete resources, so use a testing environment if possible.
* The fixture files have recorded the current error which indicates that the account does not have the permission to reserve IP. This will soon change once the account has the right permissions to reserve IP.
* There are repeated occurrences of the condition if reserveIP != nil because at the time of opening this PR, the user does not have permission to reserve an IP, so the response coming from the API is nil.
